### PR TITLE
Add basic Shopware cookie plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# gaming
+# Gaming
+
+This repository contains a sample Shopware 6 plugin called **ShopwareCookiePlugin**.
+The plugin demonstrates how to register a custom cookie in the consent manager.
+See `ShopwareCookiePlugin/README.md` for installation instructions.

--- a/ShopwareCookiePlugin/README.md
+++ b/ShopwareCookiePlugin/README.md
@@ -1,0 +1,13 @@
+# ShopwareCookiePlugin
+
+This example plugin registers a custom cookie called `example_tracking` in Shopware 6.
+After installing the plugin, the cookie appears in the "statistics" cookie group of the consent manager.
+
+## Installation
+
+Copy the plugin into the `custom/plugins` directory of your Shopware installation and run the following commands:
+
+```bash
+bin/console plugin:refresh
+bin/console plugin:install --activate ShopwareCookiePlugin
+```

--- a/ShopwareCookiePlugin/composer.json
+++ b/ShopwareCookiePlugin/composer.json
@@ -1,0 +1,22 @@
+{
+  "name": "example/shopware-cookie-plugin",
+  "description": "Example cookie management plugin for Shopware 6",
+  "type": "shopware-platform-plugin",
+  "license": "MIT",
+  "require": {
+    "shopware/core": "*",
+    "shopware/storefront": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "ShopwareCookiePlugin\\": "src/"
+    }
+  },
+  "extra": {
+    "shopware-plugin-class": "ShopwareCookiePlugin\\ShopwareCookiePlugin",
+    "label": {
+      "de-DE": "Cookie Beispiel Plugin",
+      "en-GB": "Cookie Example Plugin"
+    }
+  }
+}

--- a/ShopwareCookiePlugin/src/Cookie/ExampleCookieProvider.php
+++ b/ShopwareCookiePlugin/src/Cookie/ExampleCookieProvider.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace ShopwareCookiePlugin\Cookie;
+
+use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+use Shopware\Storefront\Framework\Cookie\CookieCollection;
+use Shopware\Storefront\Framework\Cookie\CookieStruct;
+
+class ExampleCookieProvider implements CookieProviderInterface
+{
+    public function getCookies(): CookieCollection
+    {
+        return new CookieCollection([
+            (new CookieStruct('example_tracking', CookieStruct::COOKIE_GROUP_STATISTICS))
+                ->setLifetime('30 days')
+                ->setSnippetName('cookie.configuration.exampleTracking')
+                ->setCookie('-'),
+        ]);
+    }
+}

--- a/ShopwareCookiePlugin/src/Resources/config/services.xml
+++ b/ShopwareCookiePlugin/src/Resources/config/services.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="ShopwareCookiePlugin\Cookie\ExampleCookieProvider" public="false">
+            <tag name="shopware.cookie_provider"/>
+        </service>
+    </services>
+</container>

--- a/ShopwareCookiePlugin/src/ShopwareCookiePlugin.php
+++ b/ShopwareCookiePlugin/src/ShopwareCookiePlugin.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace ShopwareCookiePlugin;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+use Shopware\Core\Framework\Plugin\Context\UninstallContext;
+
+class ShopwareCookiePlugin extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // additional install logic if needed
+    }
+
+    public function uninstall(UninstallContext $uninstallContext): void
+    {
+        parent::uninstall($uninstallContext);
+        // additional uninstall logic if needed
+    }
+}


### PR DESCRIPTION
## Summary
- document repository purpose
- create a basic Shopware 6 plugin called `ShopwareCookiePlugin`
- register a cookie via a custom provider

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68471b557ed8832db9c1bd18df43d88e