### PR TITLE
Add note about installing from zip

### DIFF
--- a/ShopwareCookiePlugin/README.md
+++ b/ShopwareCookiePlugin/README.md
@@ -5,7 +5,15 @@ After installing the plugin, the cookie appears in the "statistics" cookie group
 
 ## Installation
 
-Copy the plugin into the `custom/plugins` directory of your Shopware installation and run the following commands:
+Copy the plugin into the `custom/plugins` directory of your Shopware installation.
+
+When installing via upload, zip only the `ShopwareCookiePlugin` directory and place it in `custom/plugins`. Zipping the repository root will lead to the "No plugin found" error.
+
+```bash
+zip -r ShopwareCookiePlugin.zip ShopwareCookiePlugin
+```
+
+Run the following commands:
 
 ```bash
 bin/console plugin:refresh


### PR DESCRIPTION
## Summary
- clarify plugin installation from zipped folder

## Testing
- `composer validate --strict ShopwareCookiePlugin/composer.json` *(fails: composer not installed)*
- `php -l ShopwareCookiePlugin/src/ShopwareCookiePlugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68471d84f244832dbcd1ca27d7722505